### PR TITLE
Fixing login again

### DIFF
--- a/src/utils/nostrRelayManager.js
+++ b/src/utils/nostrRelayManager.js
@@ -437,12 +437,19 @@ class NostrRelayManager {
       relayUrls: relayUrls
     })
 
-    // Subscribe
-    // IMPORTANT: nostr-tools subscribeMany expects filters directly
-    // If we have multiple filters, we pass them as separate calls OR as array
-    // Based on the type signature: subscribeMany(relays: string[], filter: Filter, params)
-    // where Filter can be a single object OR an array of filter objects
-    const sub = this.pool.subscribeMany(relayUrls, validFilters, {
+    // Subscribe using subscribeMap instead of subscribeMany
+    // This is the correct way to send multiple filters to multiple relays
+    // subscribeMap expects: [{ url: string, filter: Filter }]
+    // where Filter is a SINGLE filter object, not an array
+    const requests = []
+    for (const url of relayUrls) {
+      for (const filter of validFilters) {
+        requests.push({ url, filter })
+      }
+    }
+
+    console.log('📡 Creating subscribeMap with', requests.length, 'requests')
+    const sub = this.pool.subscribeMap(requests, {
       ...wrappedOptions,
       maxWait: options.maxWait || 10000
     })

--- a/src/utils/nostrRelayManager.js
+++ b/src/utils/nostrRelayManager.js
@@ -1,6 +1,22 @@
 import { SimplePool } from 'nostr-tools/pool'
 import { finalizeEvent, verifyEvent } from 'nostr-tools/pure'
 
+// Debug WebSocket sends to see what's actually being transmitted
+if (typeof window !== 'undefined' && typeof WebSocket !== 'undefined') {
+  const OriginalWebSocket = window.WebSocket
+  window.WebSocket = function(...args) {
+    const ws = new OriginalWebSocket(...args)
+    const originalSend = ws.send
+    ws.send = function(data) {
+      if (typeof data === 'string' && data.includes('"REQ"')) {
+        console.log('🔍 WebSocket sending:', data)
+      }
+      return originalSend.call(this, data)
+    }
+    return ws
+  }
+}
+
 // Relay connection manager following nostr-tools best practices
 class NostrRelayManager {
   constructor() {
@@ -414,12 +430,24 @@ class NostrRelayManager {
 
     // Debug log the filters being sent
     console.log('📡 Subscribing to relays with filters:', JSON.stringify(validFilters))
+    console.log('📡 Filter type check:', {
+      isArray: Array.isArray(validFilters),
+      length: validFilters?.length,
+      firstFilter: validFilters?.[0],
+      relayUrls: relayUrls
+    })
 
     // Subscribe
+    // IMPORTANT: nostr-tools subscribeMany expects filters directly
+    // If we have multiple filters, we pass them as separate calls OR as array
+    // Based on the type signature: subscribeMany(relays: string[], filter: Filter, params)
+    // where Filter can be a single object OR an array of filter objects
     const sub = this.pool.subscribeMany(relayUrls, validFilters, {
       ...wrappedOptions,
       maxWait: options.maxWait || 10000
     })
+
+    console.log('📡 Subscription created successfully')
     // Store for deduplication
     const timeout = setTimeout(() => {
       sub.close()

--- a/src/utils/nostrRelayManager.js
+++ b/src/utils/nostrRelayManager.js
@@ -411,6 +411,10 @@ class NostrRelayManager {
       }
       if (options.onclose) options.onclose(reason)
     }
+
+    // Debug log the filters being sent
+    console.log('📡 Subscribing to relays with filters:', JSON.stringify(validFilters))
+
     // Subscribe
     const sub = this.pool.subscribeMany(relayUrls, validFilters, {
       ...wrappedOptions,

--- a/src/utils/profileFetcher.js
+++ b/src/utils/profileFetcher.js
@@ -71,6 +71,10 @@ export const fetchProfile = async (pubkey, { ttl = 24 * 60 * 60 * 1000 } = {}) =
 
 // Internal single-profile fetch via subscription (uses nostrRelayManager)
 const _fetchProfileFromRelays = async (pubkey) => {
+  if (!pubkey || typeof pubkey !== 'string' || pubkey.length !== 64) {
+    throw new Error(`Invalid pubkey for profile fetch: ${pubkey}`)
+  }
+
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error('Profile fetch timeout')), 15000)
 
@@ -111,7 +115,10 @@ const _fetchProfileFromRelays = async (pubkey) => {
 
 // Batch fetch profiles for many pubkeys. Updates profileCache as results arrive.
 export const batchFetchProfiles = async (pubkeys = [], { batchSize = 50, timeoutMs = 10000 } = {}) => {
-  const missing = pubkeys.filter(pk => pk && !profileCache.has(pk))
+  // Filter out invalid pubkeys
+  const validPubkeys = pubkeys.filter(pk => pk && typeof pk === 'string' && pk.length === 64)
+  const missing = validPubkeys.filter(pk => !profileCache.has(pk))
+
   if (missing.length === 0) return
 
   // Split into batches to avoid overly long author lists


### PR DESCRIPTION
Useed pool.subscribeMap() instead, which expects an explicit mapping of { url, filter } pairs where each filter is a single filter object (not an array).