### PR TITLE
Relay architecture fix + SocialDesk scroll fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, provide, watch, onMounted, nextTick, computed, onUnmounted, defineAsyncComponent } from 'vue'
-import { IconAlertTriangle, IconX, IconRefresh } from '@iconify-prerendered/vue-tabler'
+import { IconAlertTriangle, IconX, IconRefresh, IconExternalLink } from '@iconify-prerendered/vue-tabler'
 import Sidebar from './components/layout/Sidebar.vue'
 import { useContentZaps } from './composables/content/useContentZaps.js'
 import { generateAvatar } from './utils/profile/avatarGenerator.js'
@@ -747,9 +747,36 @@ const handleHelpClose = () => {
   showHelpModal.value = false
 }
 
+// ── No-extension modal ────────────────────────────────────────
+const showNoExtensionModal = ref(false)
+
+const detectedBrowser = computed(() => {
+  if (typeof navigator === 'undefined') return { name: 'Chrome', store: 'chrome' }
+  const ua = navigator.userAgent
+  if (ua.includes('Firefox')) return { name: 'Firefox', store: 'firefox' }
+  if (ua.includes('Edg/')) return { name: 'Edge', store: 'chrome' }
+  if (ua.includes('OPR') || ua.includes('Opera')) return { name: 'Opera', store: 'chrome' }
+  if (ua.includes('Brave')) return { name: 'Brave', store: 'chrome' }
+  if (ua.includes('Chrome')) return { name: 'Chrome', store: 'chrome' }
+  if (ua.includes('Safari')) return { name: 'Safari', store: 'unsupported' }
+  return { name: 'your browser', store: 'chrome' }
+})
+
+const jumpInstallUrl = computed(() => {
+  if (detectedBrowser.value.store === 'firefox') {
+    return 'https://addons.mozilla.org/en-US/firefox/addon/aspect-extension/'
+  }
+  return 'https://chromewebstore.google.com/detail/aspect-nostr-signer/jliekadcmakmcjbehgoagipgkbpohjfg'
+})
+
+// ── Login overlay ─────────────────────────────────────────────
+const showLoginOverlay = ref(false)
+const loginOverlayStatus = ref('Connecting...')
+
 const showLoginError = (err) => {
+  showLoginOverlay.value = false
   if (err.message?.includes('No Nostr extension')) {
-    showLoginStatus('No Nostr extension found. Please install a NIP-07 browser extension — we recommend Jump by Buho (from the ZapTracker founders, available for Firefox & Chrome), or Alby, nos2x, or Flamingo — and refresh this page.')
+    showNoExtensionModal.value = true
   } else {
     showLoginStatus(getUserFriendlyError(err))
   }
@@ -829,9 +856,14 @@ const runPostLoginLoader = () => runLoadingSequence()
 
 const handleTriggerLogin = async () => {
   try {
+    showLoginOverlay.value = true
+    loginOverlayStatus.value = 'Looking for Nostr extension...'
+
     // Re-read stored user info for loader greeting (login() writes to localStorage)
     loadingPhase.value = 'session'
+    loginOverlayStatus.value = 'Connecting to your extension...'
     await login()
+    loginOverlayStatus.value = 'Loading your profile...'
 
     // After login, read the freshly stored user for the loader display
     const raw = storageService.getRaw('nostrUser')
@@ -843,6 +875,7 @@ const handleTriggerLogin = async () => {
       } catch (e) { /* ignore */ }
     }
 
+    showLoginOverlay.value = false
     await runPostLoginLoader()
   } catch (error) {
     showLoginError(error)
@@ -1177,12 +1210,204 @@ const handleChecklistTaskAction = async (action) => {
       </transition>
     </Teleport>
 
+    <!-- Login Loading Overlay -->
+    <Teleport to="#modal-root">
+      <transition name="modal-transition">
+        <div
+          v-if="showLoginOverlay"
+          class="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-br from-gray-900/80 via-gray-900/70 to-gray-900/80 backdrop-blur-xl"
+        >
+          <div class="text-center px-8">
+            <!-- Animated Nostr logo ring -->
+            <div class="relative w-24 h-24 mx-auto mb-8">
+              <div class="absolute inset-0 rounded-full border-[3px] border-orange-500/20"></div>
+              <div class="absolute inset-0 rounded-full border-[3px] border-transparent border-t-orange-500 animate-spin" style="animation-duration: 1.2s"></div>
+              <div class="absolute inset-2 rounded-full border-[2px] border-transparent border-b-amber-400 animate-spin" style="animation-duration: 1.8s; animation-direction: reverse"></div>
+              <div class="absolute inset-0 flex items-center justify-center">
+                <svg class="w-10 h-10 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M13.6 2.4a1.6 1.6 0 0 0-3.2 0v6.4L7.2 5.6a1.6 1.6 0 0 0-2.3 2.3L8.1 11H1.6a1.6 1.6 0 0 0 0 3.2h6.5l-3.2 3.2a1.6 1.6 0 0 0 2.3 2.3l3.2-3.2v6.4a1.6 1.6 0 0 0 3.2 0v-6.4l3.2 3.2a1.6 1.6 0 0 0 2.3-2.3l-3.2-3.2h6.4a1.6 1.6 0 0 0 0-3.2h-6.5l3.2-3.1a1.6 1.6 0 0 0-2.3-2.3L13.6 8.8z"/>
+                </svg>
+              </div>
+            </div>
+            <p class="text-white text-lg font-semibold mb-2">{{ loginOverlayStatus }}</p>
+            <p class="text-white/50 text-sm">Please approve the request in your extension</p>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
+
+    <!-- No Extension Modal -->
+    <Teleport to="#modal-root">
+      <transition name="modal-transition">
+        <div
+          v-if="showNoExtensionModal"
+          class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          @click.self="showNoExtensionModal = false"
+        >
+          <div class="bg-white rounded-2xl max-w-md w-full shadow-2xl overflow-hidden">
+            <!-- Cinematic header with browser-specific illustration -->
+            <div class="relative bg-gradient-to-br from-orange-500 via-amber-500 to-yellow-500 px-8 pt-10 pb-16 text-center overflow-hidden">
+              <!-- Background decoration -->
+              <div class="absolute -top-10 -left-10 w-36 h-36 bg-white/10 rounded-full"></div>
+              <div class="absolute -bottom-6 -right-8 w-28 h-28 bg-white/8 rounded-full"></div>
+              <div class="absolute top-6 right-14 w-6 h-6 bg-white/15 rounded-full"></div>
+              <div class="absolute bottom-12 left-10 w-4 h-4 bg-white/12 rounded-full"></div>
+
+              <!-- Browser + Extension install illustration -->
+              <div class="relative w-28 h-28 mx-auto mb-5">
+                <svg viewBox="0 0 112 112" fill="none" class="w-full h-full drop-shadow-lg">
+                  <!-- Browser window frame -->
+                  <rect x="8" y="16" width="96" height="72" rx="8" fill="white" opacity="0.15"/>
+                  <rect x="12" y="20" width="88" height="64" rx="6" stroke="white" stroke-width="2.5" opacity="0.9"/>
+                  <!-- Title bar dots -->
+                  <circle cx="24" cy="29" r="2.5" fill="white" opacity="0.6"/>
+                  <circle cx="33" cy="29" r="2.5" fill="white" opacity="0.6"/>
+                  <circle cx="42" cy="29" r="2.5" fill="white" opacity="0.6"/>
+                  <!-- URL bar -->
+                  <rect x="20" y="36" width="72" height="8" rx="4" fill="white" opacity="0.2"/>
+
+                  <!-- Firefox icon (when Firefox detected) -->
+                  <g v-if="detectedBrowser.store === 'firefox'">
+                    <circle cx="56" cy="62" r="14" fill="white" opacity="0.25"/>
+                    <circle cx="56" cy="62" r="10" fill="white" opacity="0.9"/>
+                    <path d="M56 54c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 13c-2.8 0-5-2.2-5-5s2.2-5 5-5c.7 0 1.4.2 2 .4-.5.5-.8 1.1-.8 1.8 0 1.4 1.1 2.5 2.5 2.5.7 0 1.3-.3 1.8-.8.2.6.4 1.3.4 2 .1 2.8-2.1 5.1-4.9 5.1z" fill="#FF6611"/>
+                  </g>
+
+                  <!-- Chrome icon (when Chrome/Edge/Chromium detected) -->
+                  <g v-else>
+                    <circle cx="56" cy="62" r="14" fill="white" opacity="0.25"/>
+                    <circle cx="56" cy="62" r="10" fill="white" opacity="0.9"/>
+                    <circle cx="56" cy="62" r="4" fill="#4285F4"/>
+                    <path d="M56 54l6.9 4-3.5 6h-6.8l-3.5-6z" fill="#EA4335" opacity="0.9"/>
+                    <path d="M49.1 58l-3.5 6 6.9 4 3.5-6z" fill="#34A853" opacity="0.9"/>
+                    <path d="M62.9 58l3.5 6-6.9 4-3.5-6z" fill="#FBBC05" opacity="0.9"/>
+                  </g>
+
+                  <!-- Puzzle piece (extension) floating in -->
+                  <g class="ext-puzzle-float">
+                    <rect x="76" y="4" width="28" height="28" rx="6" fill="white" opacity="0.95"/>
+                    <path d="M90 11v4h-2.5c-1.1 0-2 .9-2 2s.9 2 2 2H90v4h-4c0-1.1-.9-2-2-2s-2 .9-2 2h-4V11h12z" fill="#F97316"/>
+                  </g>
+
+                  <!-- Arrow pointing down from puzzle to browser -->
+                  <path d="M90 34 L90 42 L86 38 M90 42 L94 38" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.7"/>
+                </svg>
+              </div>
+
+              <h3 class="text-2xl font-bold text-white">Install Jump for {{ detectedBrowser.name }}</h3>
+              <p class="text-white/80 text-sm mt-1">One-click setup — your keys stay in your browser</p>
+
+              <button
+                @click="showNoExtensionModal = false"
+                class="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-white/20 text-white hover:bg-white/30 transition-colors"
+                aria-label="Close"
+              >
+                <IconX class="w-4 h-4" />
+              </button>
+            </div>
+
+            <!-- Content -->
+            <div class="px-8 py-6 -mt-8 relative">
+              <!-- Step-by-step install card -->
+              <div class="bg-white rounded-xl border border-gray-100 shadow-sm p-5 mb-5">
+
+                <!-- Step 1: Install -->
+                <div class="flex gap-3 mb-4">
+                  <div class="w-7 h-7 rounded-full bg-orange-500 text-white text-xs font-bold flex items-center justify-center flex-shrink-0">1</div>
+                  <div class="flex-1">
+                    <p class="text-sm font-semibold text-gray-900 mb-1">Add the extension</p>
+                    <a
+                      :href="jumpInstallUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-3 p-3 rounded-xl bg-orange-50 border border-orange-200/60 hover:bg-orange-100 transition-colors group"
+                    >
+                      <div class="w-10 h-10 rounded-xl bg-orange-500 flex items-center justify-center flex-shrink-0">
+                        <!-- Browser store icon -->
+                        <svg v-if="detectedBrowser.store === 'firefox'" class="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9.22.66.7 1.15 1.31 1.4-.1.47-.15.95-.15 1.45 0 2.84 2.2 5.15 5 5.15.55 0 1.08-.09 1.58-.25.27.82 1.05 1.42 1.97 1.42.43 0 .83-.13 1.16-.36A7.96 7.96 0 0 1 12 20z"/>
+                        </svg>
+                        <svg v-else class="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+                        </svg>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm font-semibold text-gray-900">Jump by Buho</p>
+                        <p class="text-xs text-gray-500">
+                          {{ detectedBrowser.store === 'firefox' ? 'Firefox Add-ons' : 'Chrome Web Store' }}
+                          <span class="text-orange-500 font-medium ml-1">— Install free</span>
+                        </p>
+                      </div>
+                      <IconExternalLink class="w-4 h-4 text-gray-400 group-hover:text-orange-500 flex-shrink-0" />
+                    </a>
+                  </div>
+                </div>
+
+                <!-- Step 2: Create or import -->
+                <div class="flex gap-3 mb-4">
+                  <div class="w-7 h-7 rounded-full bg-gray-200 text-gray-600 text-xs font-bold flex items-center justify-center flex-shrink-0">2</div>
+                  <div class="flex-1">
+                    <p class="text-sm font-semibold text-gray-900 mb-0.5">Create or import your keys</p>
+                    <p class="text-xs text-gray-500 leading-relaxed">Jump will walk you through it — generate new keys or import an existing nsec</p>
+                  </div>
+                </div>
+
+                <!-- Step 3: Refresh -->
+                <div class="flex gap-3">
+                  <div class="w-7 h-7 rounded-full bg-gray-200 text-gray-600 text-xs font-bold flex items-center justify-center flex-shrink-0">3</div>
+                  <div class="flex-1">
+                    <p class="text-sm font-semibold text-gray-900 mb-0.5">Come back and connect</p>
+                    <p class="text-xs text-gray-500 leading-relaxed">Refresh this page and click "Connect with Nostr" — done</p>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Alternatives (collapsed) -->
+              <details class="mb-5 group">
+                <summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors flex items-center gap-1 select-none">
+                  <svg class="w-3 h-3 transition-transform group-open:rotate-90" viewBox="0 0 12 12" fill="currentColor"><path d="M4 2l4 4-4 4"/></svg>
+                  Other NIP-07 extensions
+                </summary>
+                <div class="flex flex-wrap gap-2 mt-2.5 pl-4">
+                  <a href="https://getalby.com" target="_blank" rel="noopener noreferrer"
+                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                  >Alby <IconExternalLink class="w-3 h-3 text-gray-400" /></a>
+                  <a href="https://github.com/nickodev/nos2x" target="_blank" rel="noopener noreferrer"
+                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                  >nos2x <IconExternalLink class="w-3 h-3 text-gray-400" /></a>
+                  <a href="https://www.getflamingo.org" target="_blank" rel="noopener noreferrer"
+                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                  >Flamingo <IconExternalLink class="w-3 h-3 text-gray-400" /></a>
+                </div>
+              </details>
+
+              <button
+                @click="showNoExtensionModal = false; location.reload()"
+                class="w-full py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold rounded-xl hover:shadow-lg transition-all duration-200 hover:scale-[1.01]"
+              >
+                I've installed it — refresh page
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
+
     <!-- PWA Install Banner -->
     <PwaInstallBanner />
   </div>
 </template>
 
 <style scoped>
+/* Extension puzzle piece float animation */
+.ext-puzzle-float {
+  animation: puzzleFloat 2.5s ease-in-out infinite;
+}
+@keyframes puzzleFloat {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
 /* Writing mode styles */
 .writing-mode {
   background: #fafafa !important;

--- a/src/components/settings/NostrSettings.vue
+++ b/src/components/settings/NostrSettings.vue
@@ -26,6 +26,7 @@ const {
   connectedRelays,
   readRelays,
   writeRelays,
+  runtimeRelayCount,
   addRelay,
   removeRelay,
   checkRelayStatus,
@@ -207,6 +208,7 @@ const getNipLabel = (nip) => nipDescriptions[nip] || `NIP-${nip}`
               <h3 class="text-base font-semibold text-gray-900">Relay Network</h3>
               <p class="text-xs text-gray-500">
                 {{ connectedRelays.length }}/{{ userRelays.length }} connected
+                <span v-if="runtimeRelayCount > 0" class="text-blue-500"> &middot; +{{ runtimeRelayCount }} outbox</span>
                 <span v-if="relayInfoError" class="text-amber-600"> &middot; info unavailable</span>
               </p>
             </div>
@@ -237,8 +239,15 @@ const getNipLabel = (nip) => nipDescriptions[nip] || `NIP-${nip}`
             </div>
             <div class="bg-gray-50 rounded-xl p-2.5 text-center">
               <div class="text-lg font-bold text-gray-600">{{ userRelays.length }}</div>
-              <div class="text-xs text-gray-700">Total</div>
+              <div class="text-xs text-gray-700">Saved</div>
             </div>
+          </div>
+          <!-- Runtime relay info -->
+          <div v-if="runtimeRelayCount > 0" class="mb-3 px-3 py-2 bg-blue-50 rounded-lg flex items-center gap-2">
+            <IconPlugConnected class="w-3.5 h-3.5 text-blue-500 flex-shrink-0" />
+            <p class="text-xs text-blue-700">
+              <span class="font-medium">{{ runtimeRelayCount }} outbox relays</span> active for event routing (ephemeral, not saved)
+            </p>
           </div>
 
           <!-- Add Relay -->

--- a/src/components/shared/ErrorBoundary.vue
+++ b/src/components/shared/ErrorBoundary.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="flex-1 min-h-0">
     <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
       <div class="flex items-start space-x-3">
         <IconAlertTriangle class="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />

--- a/src/composables/auth/useNostrAuth.js
+++ b/src/composables/auth/useNostrAuth.js
@@ -4,7 +4,7 @@ import { nostrService } from '../../services/nostr/NostrService.js'
 import { signerService } from '../../services/nostr/SignerService.js'
 import { initializeNWC } from '../../utils/wallet/nwcClient.js'
 import { profileService } from '../../services/nostr/ProfileService.js'
-import { DEFAULT_RELAY_CONFIGS_WITH_STATUS } from '../../utils/constants.js'
+import { DEFAULT_RELAY_CONFIGS_WITH_STATUS, MAX_PERSISTENT_RELAYS } from '../../utils/constants.js'
 import { stopRefreshCycle } from '../../utils/refreshCycle.js'
 import { getUserFriendlyError } from '../../services/nostr/errors.js'
 import { storageService, STORAGE_KEYS } from '../../services/StorageService.js'
@@ -55,11 +55,14 @@ const saveRelaysToStorage = (relayData) => {
   storageService.set(STORAGE_KEYS.RELAYS, relayData)
 }
 
-// Sync relay statuses from relay manager
+// Sync relay statuses from relay manager.
+// IMPORTANT: Only updates status for relays already in the persistent set.
+// Runtime/outbox/inbox relays discovered by NostrService stay ephemeral —
+// they are never promoted into userRelays or written to storage.
 const syncRelayStatuses = () => {
   const managerStatuses = nostrService.getRelayStatuses()
-  
-  // Update userRelays with current statuses
+
+  // Update persistent userRelays with current statuses (status fields only)
   userRelays.value = userRelays.value.map(relay => {
     const managerStatus = managerStatuses.find(s => s.url === relay.url)
     if (managerStatus) {
@@ -73,25 +76,10 @@ const syncRelayStatuses = () => {
     }
     return relay
   })
-  
-  // Add any new relays from manager that aren't in userRelays
-  managerStatuses.forEach(managerStatus => {
-    const exists = userRelays.value.find(r => r.url === managerStatus.url)
-    if (!exists && managerStatus.config) {
-      userRelays.value.push({
-        url: managerStatus.url,
-        status: managerStatus.status,
-        read: managerStatus.config.read,
-        write: managerStatus.config.write,
-        error: managerStatus.error,
-        lastUpdated: managerStatus.lastUpdated,
-        lastConnected: managerStatus.lastConnected
-      })
-    }
-  })
-  
-  // Save updated relays
-  saveRelaysToStorage(userRelays.value)
+
+  // NOTE: We intentionally do NOT append unknown manager relays into userRelays.
+  // Outbox/inbox relays are routing hints, not user preferences.
+  // They live only in NostrService.relayStatuses for the duration of the session.
 }
 
 // Fetch user profile using ProfileService
@@ -308,20 +296,22 @@ const fetchUserRelayList = async (pubkey) => {
   }
 }
 
-// Update relay manager with user's relays
+// Update relay manager with user's own NIP-65 relay preferences.
+// Only the logged-in user's kind:10002 relays become persistent preferences.
+// Other users' relay lists are handled as ephemeral outbox/inbox routing hints
+// by NostrService.getOutboxRelays / getInboxRelays.
 const updateRelaysFromNip65 = async (pubkey) => {
   const nip65Relays = await fetchUserRelayList(pubkey)
-  
+
   if (nip65Relays && nip65Relays.length > 0) {
-    // Merge NIP-65 relays with existing relays (NIP-65 takes priority)
     const existingUrls = new Set(userRelays.value.map(r => r.url))
     const newRelays = []
-    
+
     for (const relay of nip65Relays) {
       if (!existingUrls.has(relay.url)) {
         newRelays.push(relay)
       } else {
-        // Update existing relay with NIP-65 settings
+        // Update existing relay with NIP-65 read/write flags
         const existingIndex = userRelays.value.findIndex(r => r.url === relay.url)
         if (existingIndex !== -1) {
           userRelays.value[existingIndex] = {
@@ -332,10 +322,13 @@ const updateRelaysFromNip65 = async (pubkey) => {
         }
       }
     }
-    
-    // Add new relays from NIP-65
+
+    // Add new relays from NIP-65, but respect the persistent relay cap
     if (newRelays.length > 0) {
-      userRelays.value = [...userRelays.value, ...newRelays]
+      const headroom = MAX_PERSISTENT_RELAYS - userRelays.value.length
+      if (headroom > 0) {
+        userRelays.value = [...userRelays.value, ...newRelays.slice(0, headroom)]
+      }
     }
 
     // Save updated relays
@@ -347,10 +340,10 @@ const updateRelaysFromNip65 = async (pubkey) => {
     } catch (error) {
       console.warn('Failed to update relay manager:', error)
     }
-    
+
     return true
   }
-  
+
   return false
 }
 
@@ -598,6 +591,40 @@ const logout = () => {
   }
 }
 
+// Trim an oversized stored relay list down to the cap.
+// Keeps all defaults first, then fills the rest with the most recently
+// connected relays from the stored list.
+const trimRelayList = (relays) => {
+  if (relays.length <= MAX_PERSISTENT_RELAYS) return relays
+
+  const defaultUrls = new Set(DEFAULT_RELAYS.map(r => r.url))
+  const kept = []
+  const rest = []
+
+  for (const relay of relays) {
+    if (defaultUrls.has(relay.url)) {
+      kept.push(relay)
+    } else {
+      rest.push(relay)
+    }
+  }
+
+  // Sort non-default relays by most recently connected (descending)
+  rest.sort((a, b) => {
+    const aTime = a.lastConnected ? new Date(a.lastConnected).getTime() : 0
+    const bTime = b.lastConnected ? new Date(b.lastConnected).getTime() : 0
+    return bTime - aTime
+  })
+
+  const headroom = MAX_PERSISTENT_RELAYS - kept.length
+  const trimmed = [...kept, ...rest.slice(0, Math.max(0, headroom))]
+
+  console.info(
+    `[relay-migration] Trimmed persistent relay list from ${relays.length} to ${trimmed.length} (cap: ${MAX_PERSISTENT_RELAYS})`
+  )
+  return trimmed
+}
+
 // Initialize auth and relays - simplified for NIP-07 only
 const initAuthAndRelays = async () => {
   if (isInitialized) return
@@ -610,6 +637,13 @@ const initAuthAndRelays = async () => {
     // Load or initialize relays
     if (!loadRelaysFromStorage()) {
       userRelays.value = [...DEFAULT_RELAYS]
+      saveRelaysToStorage(userRelays.value)
+    }
+
+    // Migration: trim oversized stored relay lists from previous versions
+    // that promoted runtime/outbox relays into persistent storage.
+    if (userRelays.value.length > MAX_PERSISTENT_RELAYS) {
+      userRelays.value = trimRelayList(userRelays.value)
       saveRelaysToStorage(userRelays.value)
     }
 
@@ -691,6 +725,14 @@ const connectedRelays = computed(() => userRelays.value.filter(relay => relay.st
 const readRelays = computed(() => userRelays.value.filter(relay => relay.read && relay.status === 'connected'))
 const writeRelays = computed(() => userRelays.value.filter(relay => relay.write && relay.status === 'connected'))
 
+// Runtime relay count: relays connected by NostrService for outbox/inbox routing
+// that are NOT in the persistent user relay list.
+const runtimeRelayCount = computed(() => {
+  const persistentUrls = new Set(userRelays.value.map(r => r.url))
+  const allServiceRelays = nostrService.getRelayStatuses()
+  return allServiceRelays.filter(r => !persistentUrls.has(r.url)).length
+})
+
 // Watch for changes and save to storage (debounced to avoid localStorage thrashing)
 let _authSaveTimer = null
 const debouncedSaveUser = () => {
@@ -729,6 +771,7 @@ export function useNostrAuth() {
     connectedRelays,
     readRelays,
     writeRelays,
+    runtimeRelayCount,
     
     // Actions
     login,

--- a/src/pages/SocialDesk.vue
+++ b/src/pages/SocialDesk.vue
@@ -796,8 +796,8 @@ const handleLogin = async () => {
       </div>
 
       <!-- Desktop: multi-column grid -->
-      <div class="hidden md:block flex-1 min-h-0 overflow-hidden">
-        <div class="desk-columns-track flex h-full min-h-0 min-w-full items-stretch gap-3 overflow-x-auto overflow-y-hidden pb-1">
+      <div class="hidden md:flex md:flex-col flex-1 min-h-0 overflow-hidden">
+        <div class="desk-columns-track flex flex-1 min-h-0 min-w-full items-stretch gap-3 overflow-x-auto overflow-y-hidden pb-1">
         <DeskColumn
           v-for="col in columns"
           :key="col.id"

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -52,6 +52,10 @@ export const OUTBOX_RELAY_LIST_TTL = 30 * 60 * 1000  // 30min cache for relay li
 export const OUTBOX_MAX_RELAYS_PER_PUBKEY = 5         // max relays to use per user for outbox
 export const RELAY_INFO_TTL = 60 * 60 * 1000          // 1h cache for NIP-11 relay info
 
+// ── Persistent relay limits ──
+// Only user-curated + own NIP-65 relays are persisted; outbox/inbox stay ephemeral
+export const MAX_PERSISTENT_RELAYS = 50
+
 // ── Default relay list (single source of truth) ──
 export const DEFAULT_RELAY_URLS = [
   'wss://relay.damus.io',


### PR DESCRIPTION
Stop runtime/outbox relays from being promoted into persistent storage. syncRelayStatuses no longer appends unknown service relays into userRelays. NIP-65 imports respect MAX_PERSISTENT_RELAYS (50) cap. Boot migration trims oversized stored relay lists from previous versions. Settings UI now shows persistent vs ephemeral relay counts.

Fix SocialDesk column scrolling by making ErrorBoundary pass through flex height chain (flex-1 min-h-0) and switching desktop column wrapper from display:block to display:flex for reliable height propagation.